### PR TITLE
Fix import manager broker account selection

### DIFF
--- a/src/Core/Import/ImportManager.fs
+++ b/src/Core/Import/ImportManager.fs
@@ -12,176 +12,210 @@ open BrokerExtensions
 /// Main import manager for file import operations with cancellation support
 /// </summary>
 module ImportManager =
-    
+
     /// <summary>
     /// Import file for a specific broker with cancellation and progress tracking
     /// </summary>
     /// <param name="brokerId">ID of the broker to import for</param>
+    /// <param name="brokerAccountId">ID of the broker account selected in the UI</param>
     /// <param name="filePath">Path to the file to import (CSV or ZIP)</param>
     /// <returns>ImportResult with detailed feedback</returns>
-    let importFile (brokerId: int) (filePath: string) = task {
-        let cancellationToken = ImportState.startImport()
-        
-        try
-            // Validate inputs
-            ImportState.updateStatus(Validating filePath)
-            
-            if not (File.Exists(filePath)) then
-                return ImportResult.createError($"File not found: {filePath}")
-            else
-                // Look up broker information
-                let! brokerOption = BrokerExtensions.Do.getById(brokerId) |> Async.AwaitTask
-                match brokerOption with
-                | None ->
-                    return ImportResult.createError($"Broker with ID {brokerId} not found")
-                | Some broker ->
-                    cancellationToken.ThrowIfCancellationRequested()
-                    
-                    // Process file (handles both CSV and ZIP)
-                    ImportState.updateStatus(ProcessingFile(Path.GetFileName(filePath), 0.0))
-                    let processedFile = 
-                        try
-                            Some (FileProcessor.processFile filePath)
-                        with
-                        | ex -> 
-                            ImportState.failImport($"Failed to process file: {ex.Message}")
-                            None
-                    
-                    match processedFile with
-                    | None -> return ImportResult.createError($"Failed to process file")
-                    | Some pf ->
-                        try
+    let importFile (brokerId: int) (brokerAccountId: int) (filePath: string) =
+        task {
+            let cancellationToken = ImportState.startImport ()
+
+            try
+                // Validate inputs
+                ImportState.updateStatus (Validating filePath)
+
+                if not (File.Exists(filePath)) then
+                    return ImportResult.createError ($"File not found: {filePath}")
+                else
+                    // Look up broker information
+                    let! brokerOption = BrokerExtensions.Do.getById (brokerId) |> Async.AwaitTask
+
+                    match brokerOption with
+                    | None -> return ImportResult.createError ($"Broker with ID {brokerId} not found")
+                    | Some broker ->
+                        cancellationToken.ThrowIfCancellationRequested()
+
+                        let! brokerAccountOption =
+                            BrokerAccountExtensions.Do.getById (brokerAccountId) |> Async.AwaitTask
+
+                        match brokerAccountOption with
+                        | None ->
+                            return ImportResult.createError ($"Broker account with ID {brokerAccountId} not found")
+                        | Some account when account.BrokerId <> brokerId ->
+                            return
+                                ImportResult.createError (
+                                    $"Broker account {brokerAccountId} does not belong to broker {broker.Name}"
+                                )
+                        | Some brokerAccount ->
                             cancellationToken.ThrowIfCancellationRequested()
-                            
-                            // Route to appropriate broker importer based on SupportedBroker
-                            let! importResult = 
-                                if broker.SupportedBroker.ToString() = "IBKR" then
-                                    // IBKR importer doesn't need broker account ID
-                                    IBKRImporter.importMultipleWithCancellation pf.CsvFiles cancellationToken
-                                elif broker.SupportedBroker.ToString() = "Tastytrade" then
-                                    // Tastytrade importer needs broker account ID - we'll use the first available
-                                    task {
-                                        let! brokerAccounts = BrokerAccountExtensions.Do.getAll() |> Async.AwaitTask
-                                        let brokerAccount = 
-                                            brokerAccounts 
-                                            |> List.tryFind (fun account -> account.BrokerId = brokerId)
-                                        match brokerAccount with
-                                        | None ->
-                                            return ImportResult.createError($"No broker account found for broker {broker.Name}")
-                                        | Some account ->
-                                            // First do the parsing/validation
-                                            let! parseResult = TastytradeImporter.importMultipleWithCancellation pf.CsvFiles account.Id cancellationToken
-                                            
-                                            // If parsing was successful, persist to database
-                                            if parseResult.Success then
-                                                cancellationToken.ThrowIfCancellationRequested()
-                                                
-                                                try
-                                                    // Parse the transactions from files again for database persistence
-                                                    let mutable allTransactions = []
-                                                    for csvFile in pf.CsvFiles do
-                                                        let parsingResult = TastytradeStatementParser.parseTransactionHistoryFromFile csvFile
-                                                        if parsingResult.Errors.IsEmpty then
-                                                            allTransactions <- allTransactions @ parsingResult.Transactions
-                                                    
-                                                    // Persist transactions to database
-                                                    let! persistenceResult = DatabasePersistence.persistTransactionsToDatabase allTransactions account.Id cancellationToken
-                                                    
-                                                    // Use targeted reactive updates if persistence was successful and data was imported
-                                                    if persistenceResult.ErrorsCount = 0 && persistenceResult.ImportMetadata.TotalMovementsImported > 0 then
-                                                        // Refresh reactive managers in dependency order
-                                                        do! ReactiveTickerManager.refreshAsync()       // First: base ticker data
-                                                        do! ReactiveMovementManager.refreshAsync()  // Then: movements (depend on tickers)
-                                                        // Use targeted snapshot updates instead of full refresh
-                                                        do! ReactiveTargetedSnapshotManager.updateFromImport(persistenceResult.ImportMetadata)
-                                                    elif persistenceResult.ErrorsCount = 0 then
-                                                        // Fallback to full refresh if no movements were imported
-                                                        do! ReactiveTickerManager.refreshAsync()       
-                                                        do! ReactiveMovementManager.refreshAsync()
-                                                        do! ReactiveSnapshotManager.refreshAsync()
-                                                    
-                                                    // Update the ImportResult with actual database persistence results
-                                                    let updatedImportedData = {
-                                                        parseResult.ImportedData with
-                                                            Trades = persistenceResult.StockTradesCreated
-                                                            BrokerMovements = persistenceResult.BrokerMovementsCreated
-                                                            OptionTrades = persistenceResult.OptionTradesCreated
-                                                            Dividends = persistenceResult.DividendsCreated
-                                                    }
-                                                    
-                                                    // Add any persistence errors to the result
-                                                    let persistenceErrors = 
-                                                        persistenceResult.Errors |> List.map (fun err -> {
-                                                            RowNumber = None
-                                                            ErrorMessage = err
-                                                            ErrorType = ImportErrorType.ValidationError
-                                                            RawData = None
-                                                        })
-                                                    let updatedErrors = parseResult.Errors @ persistenceErrors
-                                                    
-                                                    return { parseResult with 
-                                                               ImportedData = updatedImportedData
-                                                               Errors = updatedErrors
-                                                               Success = parseResult.Success && persistenceResult.ErrorsCount = 0 }
-                                                
-                                                with
-                                                | :? OperationCanceledException ->
-                                                    return ImportResult.createCancelled()
-                                                | ex ->
-                                                    return ImportResult.createError($"Database persistence failed: {ex.Message}")
-                                            else
-                                                return parseResult
-                                    }
-                                else
-                                    task { return ImportResult.createError($"Unsupported broker type: {broker.Name}") }
-                            
-                            // Clean up temporary files
-                            FileProcessor.cleanup pf
-                            
-                            // Complete import and return result
-                            ImportState.completeImport(importResult)
-                            return importResult
-                            
-                        with
-                        | :? OperationCanceledException ->
-                            // Clean up temporary files on cancellation
-                            FileProcessor.cleanup pf
-                            return ImportResult.createCancelled()
-                        | ex ->
-                            // Clean up temporary files on error
-                            FileProcessor.cleanup pf
-                            return ImportResult.createError($"Import failed: {ex.Message}")
-        
-        with
-        | :? OperationCanceledException ->
-            return ImportResult.createCancelled()
-        | ex ->
-            ImportState.failImport(ex.Message)
-            return ImportResult.createError(ex.Message)
-    }
-    
+
+                            // Process file (handles both CSV and ZIP)
+                            ImportState.updateStatus (ProcessingFile(Path.GetFileName(filePath), 0.0))
+
+                            let processedFile =
+                                try
+                                    Some(FileProcessor.processFile filePath)
+                                with ex ->
+                                    ImportState.failImport ($"Failed to process file: {ex.Message}")
+                                    None
+
+                            match processedFile with
+                            | None -> return ImportResult.createError ($"Failed to process file")
+                            | Some pf ->
+                                try
+                                    cancellationToken.ThrowIfCancellationRequested()
+
+                                    // Route to appropriate broker importer based on SupportedBroker
+                                    let! importResult =
+                                        if broker.SupportedBroker.ToString() = "IBKR" then
+                                            // IBKR importer doesn't need broker account ID but we still validate above
+                                            IBKRImporter.importMultipleWithCancellation pf.CsvFiles cancellationToken
+                                        elif broker.SupportedBroker.ToString() = "Tastytrade" then
+                                            // Tastytrade importer requires a specific broker account ID
+                                            task {
+                                                // First do the parsing/validation
+                                                let! parseResult =
+                                                    TastytradeImporter.importMultipleWithCancellation
+                                                        pf.CsvFiles
+                                                        brokerAccount.Id
+                                                        cancellationToken
+
+                                                // If parsing was successful, persist to database
+                                                if parseResult.Success then
+                                                    cancellationToken.ThrowIfCancellationRequested()
+
+                                                    try
+                                                        // Parse the transactions from files again for database persistence
+                                                        let mutable allTransactions = []
+
+                                                        for csvFile in pf.CsvFiles do
+                                                            let parsingResult =
+                                                                TastytradeStatementParser.parseTransactionHistoryFromFile
+                                                                    csvFile
+
+                                                            if parsingResult.Errors.IsEmpty then
+                                                                allTransactions <-
+                                                                    allTransactions @ parsingResult.Transactions
+
+                                                        // Persist transactions to database
+                                                        let! persistenceResult =
+                                                            DatabasePersistence.persistTransactionsToDatabase
+                                                                allTransactions
+                                                                brokerAccount.Id
+                                                                cancellationToken
+
+                                                        // Use targeted reactive updates if persistence was successful and data was imported
+                                                        if
+                                                            persistenceResult.ErrorsCount = 0
+                                                            && persistenceResult.ImportMetadata.TotalMovementsImported > 0
+                                                        then
+                                                            // Refresh reactive managers in dependency order
+                                                            do! ReactiveTickerManager.refreshAsync () // First: base ticker data
+                                                            do! ReactiveMovementManager.refreshAsync () // Then: movements (depend on tickers)
+                                                            // Use targeted snapshot updates instead of full refresh
+                                                            do!
+                                                                ReactiveTargetedSnapshotManager.updateFromImport (
+                                                                    persistenceResult.ImportMetadata
+                                                                )
+                                                        elif persistenceResult.ErrorsCount = 0 then
+                                                            // Fallback to full refresh if no movements were imported
+                                                            do! ReactiveTickerManager.refreshAsync ()
+                                                            do! ReactiveMovementManager.refreshAsync ()
+                                                            do! ReactiveSnapshotManager.refreshAsync ()
+
+                                                        // Update the ImportResult with actual database persistence results
+                                                        let updatedImportedData =
+                                                            { parseResult.ImportedData with
+                                                                Trades = persistenceResult.StockTradesCreated
+                                                                BrokerMovements =
+                                                                    persistenceResult.BrokerMovementsCreated
+                                                                OptionTrades = persistenceResult.OptionTradesCreated
+                                                                Dividends = persistenceResult.DividendsCreated }
+
+                                                        // Add any persistence errors to the result
+                                                        let persistenceErrors =
+                                                            persistenceResult.Errors
+                                                            |> List.map (fun err ->
+                                                                { RowNumber = None
+                                                                  ErrorMessage = err
+                                                                  ErrorType = ImportErrorType.ValidationError
+                                                                  RawData = None })
+
+                                                        let updatedErrors = parseResult.Errors @ persistenceErrors
+
+                                                        return
+                                                            { parseResult with
+                                                                ImportedData = updatedImportedData
+                                                                Errors = updatedErrors
+                                                                Success =
+                                                                    parseResult.Success
+                                                                    && persistenceResult.ErrorsCount = 0 }
+
+                                                    with
+                                                    | :? OperationCanceledException ->
+                                                        return ImportResult.createCancelled ()
+                                                    | ex ->
+                                                        return
+                                                            ImportResult.createError (
+                                                                $"Database persistence failed: {ex.Message}"
+                                                            )
+                                                else
+                                                    return parseResult
+                                            }
+                                        else
+                                            task {
+                                                return
+                                                    ImportResult.createError ($"Unsupported broker type: {broker.Name}")
+                                            }
+
+                                    // Clean up temporary files
+                                    FileProcessor.cleanup pf
+
+                                    // Complete import and return result
+                                    ImportState.completeImport (importResult)
+                                    return importResult
+
+                                with
+                                | :? OperationCanceledException ->
+                                    // Clean up temporary files on cancellation
+                                    FileProcessor.cleanup pf
+                                    return ImportResult.createCancelled ()
+                                | ex ->
+                                    // Clean up temporary files on error
+                                    FileProcessor.cleanup pf
+                                    return ImportResult.createError ($"Import failed: {ex.Message}")
+
+            with
+            | :? OperationCanceledException -> return ImportResult.createCancelled ()
+            | ex ->
+                ImportState.failImport (ex.Message)
+                return ImportResult.createError (ex.Message)
+        }
+
     /// <summary>
     /// Cancel current import operation
     /// </summary>
-    let cancelCurrentImport() =
-        ImportState.cancelImport("User requested cancellation")
-    
+    let cancelCurrentImport () =
+        ImportState.cancelImport ("User requested cancellation")
+
     /// <summary>
     /// Cancel for app backgrounding
     /// </summary>
-    let cancelForBackground() =
-        ImportState.cancelForBackground()
-    
+    let cancelForBackground () = ImportState.cancelForBackground ()
+
     /// <summary>
     /// Get current import status
     /// </summary>
-    let getCurrentStatus() =
-        ImportState.ImportStatus.Value
-    
+    let getCurrentStatus () = ImportState.ImportStatus.Value
+
     /// <summary>
     /// Check if an import is currently in progress
     /// </summary>
-    let isImportInProgress() =
-        match ImportState.getCurrentCancellationToken() with
+    let isImportInProgress () =
+        match ImportState.getCurrentCancellationToken () with
         | Some token -> not token.IsCancellationRequested
         | None -> false

--- a/src/Tests/Core.Platform.MauiTester/TestCases/OptionsImportIntegrationTest.cs
+++ b/src/Tests/Core.Platform.MauiTester/TestCases/OptionsImportIntegrationTest.cs
@@ -139,8 +139,8 @@ namespace Core.Platform.MauiTester.TestCases
             if (string.IsNullOrEmpty(_tempCsvPath))
                 throw new InvalidOperationException("CSV file path is null");
 
-            // Execute the complete import workflow using the broker ID (not broker account ID)
-            var importResult = await ImportManager.importFile(_testBrokerId, _tempCsvPath);
+            // Execute the complete import workflow using the explicitly selected broker account
+            var importResult = await ImportManager.importFile(_testBrokerId, _testBrokerAccountId, _tempCsvPath);
 
             // After import, manually trigger comprehensive snapshot processing
             if (importResult.Success)

--- a/src/Tests/Core.Tests/DatabasePersistenceTests.fs
+++ b/src/Tests/Core.Tests/DatabasePersistenceTests.fs
@@ -82,6 +82,7 @@ type DatabasePersistenceTests() =
 
         // The fact that ImportManager compiles with DatabasePersistence calls means the integration is correct
         // The ImportManager.importFile method now includes:
+        // 0. Validation of the explicitly selected broker account before processing
         // 1. Parse transactions
         // 2. If successful, call DatabasePersistence.persistTransactionsToDatabase
         // 3. Update ImportResult with actual persisted counts

--- a/src/Tests/Core.Tests/ImportManagerTests.fs
+++ b/src/Tests/Core.Tests/ImportManagerTests.fs
@@ -17,70 +17,110 @@ type ImportManagerTests() =
     [<SetUp>]
     member this.Setup() =
         // Clean up any existing import state
-        ImportState.cleanup()
+        ImportState.cleanup ()
 
     [<TearDown>]
     member this.TearDown() =
         // Clean up after each test
-        ImportState.cleanup()
+        ImportState.cleanup ()
 
     [<Test>]
-    member this.``ImportManager fails for non-existent file``() = task {
-        let! result = ImportManager.importFile 1 "non-existent.csv"
-        
-        Assert.That(result.Success, Is.False, "Import should fail for non-existent file")
-        Assert.That(result.Errors.Length, Is.EqualTo(1), "Should have one error")
-        Assert.That(result.Errors.[0].ErrorMessage, Does.Contain("File not found"))
-    }
+    member this.``ImportManager fails for non-existent file``() =
+        task {
+            let! result = ImportManager.importFile 1 1 "non-existent.csv"
+
+            Assert.That(result.Success, Is.False, "Import should fail for non-existent file")
+            Assert.That(result.Errors.Length, Is.EqualTo(1), "Should have one error")
+            Assert.That(result.Errors.[0].ErrorMessage, Does.Contain("File not found"))
+        }
 
     [<Test>]
-    member this.``ImportManager fails for invalid broker ID``() = task {
-        // Create a temporary CSV file for testing
-        let tempFile = Path.GetTempFileName()
-        let csvFile = tempFile + ".csv"
-        File.Move(tempFile, csvFile)
-        File.WriteAllText(csvFile, "test,data\n1,2")
-        
-        try
-            // Test with an invalid broker ID that doesn't exist in the database
-            let! result = ImportManager.importFile 999 csvFile
-            
-            // The import should fail - either because the broker doesn't exist 
-            // or because of database configuration issues in the test environment
-            Assert.That(result.Success, Is.False, "Import should fail for non-existent broker ID or database issues")
-            Assert.That(result.Errors.Length, Is.GreaterThan(0), "Should have at least one error")
-            // Accept either the broker not found error or database configuration errors
-            let errorMessage = result.Errors.[0].ErrorMessage
-            let hasExpectedError = 
-                errorMessage.Contains("Broker with ID 999 not found") || 
-                errorMessage.Contains("This functionality is not implemented") ||
-                errorMessage.Contains("One or more errors occurred")
-            Assert.That(hasExpectedError, Is.True, $"Should have expected error type, got: {errorMessage}")
-        finally
-            if File.Exists(csvFile) then File.Delete(csvFile)
-    }
+    member this.``ImportManager fails for invalid broker ID``() =
+        task {
+            // Create a temporary CSV file for testing
+            let tempFile = Path.GetTempFileName()
+            let csvFile = tempFile + ".csv"
+            File.Move(tempFile, csvFile)
+            File.WriteAllText(csvFile, "test,data\n1,2")
+
+            try
+                // Test with an invalid broker ID that doesn't exist in the database
+                let! result = ImportManager.importFile 999 42 csvFile
+
+                // The import should fail - either because the broker doesn't exist
+                // or because of database configuration issues in the test environment
+                Assert.That(
+                    result.Success,
+                    Is.False,
+                    "Import should fail for non-existent broker ID or database issues"
+                )
+
+                Assert.That(result.Errors.Length, Is.GreaterThan(0), "Should have at least one error")
+                // Accept either the broker not found error or database configuration errors
+                let errorMessage = result.Errors.[0].ErrorMessage
+
+                let hasExpectedError =
+                    errorMessage.Contains("Broker with ID 999 not found")
+                    || errorMessage.Contains("This functionality is not implemented")
+                    || errorMessage.Contains("One or more errors occurred")
+
+                Assert.That(hasExpectedError, Is.True, $"Should have expected error type, got: {errorMessage}")
+            finally
+                if File.Exists(csvFile) then
+                    File.Delete(csvFile)
+        }
+
+    [<Test>]
+    member this.``ImportManager fails for invalid broker account``() =
+        task {
+            // Create a temporary CSV file for testing
+            let tempFile = Path.GetTempFileName()
+            let csvFile = tempFile + ".csv"
+            File.Move(tempFile, csvFile)
+            File.WriteAllText(csvFile, "test,data\n1,2")
+
+            try
+                let! result = ImportManager.importFile 1 999 csvFile
+
+                Assert.That(result.Success, Is.False, "Import should fail for invalid broker account")
+                Assert.That(result.Errors.Length, Is.GreaterThan(0), "Should have at least one error")
+
+                let errorMessage = result.Errors.[0].ErrorMessage
+
+                let hasExpectedError =
+                    errorMessage.Contains("Broker account with ID 999 not found")
+                    || errorMessage.Contains("Broker with ID 1 not found")
+                    || errorMessage.Contains("This functionality is not implemented")
+                    || errorMessage.Contains("One or more errors occurred")
+
+                Assert.That(hasExpectedError, Is.True, $"Should have expected error type, got: {errorMessage}")
+            finally
+                if File.Exists(csvFile) then
+                    File.Delete(csvFile)
+        }
 
     [<Test>]
     member this.``ImportState starts and manages cancellation correctly``() =
-        let token1 = ImportState.startImport()
+        let token1 = ImportState.startImport ()
         Assert.That(token1.IsCancellationRequested, Is.False, "New token should not be cancelled")
-        
-        ImportState.cancelImport("Test cancellation")
+
+        ImportState.cancelImport ("Test cancellation")
         Assert.That(token1.IsCancellationRequested, Is.True, "Token should be cancelled after cancellation")
-        
+
         // Start a new import - should get a fresh token
-        let token2 = ImportState.startImport()
+        let token2 = ImportState.startImport ()
         Assert.That(token2.IsCancellationRequested, Is.False, "New token should not be cancelled")
 
     [<Test>]
     member this.``ImportState tracks status changes``() =
         let initialStatus = ImportState.ImportStatus.Value
         Assert.That(initialStatus, Is.EqualTo(NotStarted), "Initial status should be NotStarted")
-        
-        ImportState.startImport() |> ignore
-        ImportState.updateStatus(Validating "test.csv")
-        
+
+        ImportState.startImport () |> ignore
+        ImportState.updateStatus (Validating "test.csv")
+
         let currentStatus = ImportState.ImportStatus.Value
+
         match currentStatus with
         | Validating filePath -> Assert.That(filePath, Is.EqualTo("test.csv"))
         | _ -> Assert.Fail("Status should be Validating")
@@ -88,90 +128,105 @@ type ImportManagerTests() =
     [<Test>]
     member this.``FileProcessor handles CSV files correctly``() =
         let tempFile = Path.GetTempFileName()
-        let csvFile = tempFile + ".csv"  // Simple concatenation instead of ChangeExtension
+        let csvFile = tempFile + ".csv" // Simple concatenation instead of ChangeExtension
         File.Move(tempFile, csvFile)
         File.WriteAllText(csvFile, "header1,header2\nvalue1,value2")
-        
+
         try
             let result = FileProcessor.processFile csvFile
-            
+
             Assert.That(result.IsTemporary, Is.False, "CSV file should not be temporary")
             Assert.That(result.CsvFiles.Length, Is.EqualTo(1), "Should have one CSV file")
             Assert.That(result.CsvFiles.[0], Is.EqualTo(csvFile), "Should return the same file path")
-            
+
             Assert.That(FileProcessor.validateCsvFiles result, Is.True, "CSV file should be valid")
             Assert.That(FileProcessor.getTotalFileSize result, Is.GreaterThan(0L), "File should have content")
         finally
-            if File.Exists(csvFile) then File.Delete(csvFile)
+            if File.Exists(csvFile) then
+                File.Delete(csvFile)
 
-    [<Test>] 
+    [<Test>]
     member this.``FileProcessor fails for unsupported file types``() =
         let tempFile = Path.GetTempFileName()
-        let txtFile = tempFile + ".txt"  // Simple concatenation instead of ChangeExtension
+        let txtFile = tempFile + ".txt" // Simple concatenation instead of ChangeExtension
         File.Move(tempFile, txtFile)
         File.WriteAllText(txtFile, "test content")
-        
+
         try
-            Assert.Throws<System.Exception>(fun () -> 
-                FileProcessor.processFile txtFile |> ignore
-            ) |> ignore
+            Assert.Throws<System.Exception>(fun () -> FileProcessor.processFile txtFile |> ignore)
+            |> ignore
         finally
-            if File.Exists(txtFile) then File.Delete(txtFile)
+            if File.Exists(txtFile) then
+                File.Delete(txtFile)
 
     [<Test>]
     member this.``FileProcessor handles ZIP files correctly``() =
         let tempDir = Path.GetTempPath()
         let zipFile = Path.Combine(tempDir, Path.GetRandomFileName() + ".zip")
         let csvContent = "header1,header2\nvalue1,value2"
-        
+
         try
             // Create a ZIP file with a CSV inside using the static method
             let tempCsvFile = Path.GetTempFileName() + ".csv"
             File.WriteAllText(tempCsvFile, csvContent)
-            
+
             // Use the static method to create zip from files
-            use archive = System.IO.Compression.ZipFile.Open(zipFile, System.IO.Compression.ZipArchiveMode.Create)
+            use archive =
+                System.IO.Compression.ZipFile.Open(zipFile, System.IO.Compression.ZipArchiveMode.Create)
+
             let entry = archive.CreateEntry("test.csv")
             use entryStream = entry.Open()
             let csvBytes = System.Text.Encoding.UTF8.GetBytes(csvContent)
             entryStream.Write(csvBytes, 0, csvBytes.Length)
             entryStream.Close()
             archive.Dispose()
-            
+
             File.Delete(tempCsvFile) // Clean up temp CSV
-            
+
             let result = FileProcessor.processFile zipFile
-            
+
             Assert.That(result.IsTemporary, Is.True, "ZIP extraction should create temporary files")
             Assert.That(result.CsvFiles.Length, Is.EqualTo(1), "Should find one CSV file")
             Assert.That(File.Exists(result.CsvFiles.[0]), Is.True, "Extracted CSV file should exist")
-            
+
             // Verify content
             let extractedContent = File.ReadAllText(result.CsvFiles.[0])
             Assert.That(extractedContent, Is.EqualTo(csvContent), "Content should match")
-            
+
             // Test cleanup
             FileProcessor.cleanup result
             Assert.That(Directory.Exists(result.FilePath), Is.False, "Temporary directory should be cleaned up")
-            
+
         finally
-            if File.Exists(zipFile) then File.Delete(zipFile)
+            if File.Exists(zipFile) then
+                File.Delete(zipFile)
 
     [<Test>]
     member this.``ImportResult helper functions work correctly``() =
-        let importedData = { Trades = 5; BrokerMovements = 3; Dividends = 2; OptionTrades = 1; NewTickers = 4 }
-        let fileResults = [FileImportResult.createSuccess "test.csv" 10]
-        
+        let importedData =
+            { Trades = 5
+              BrokerMovements = 3
+              Dividends = 2
+              OptionTrades = 1
+              NewTickers = 4 }
+
+        let fileResults = [ FileImportResult.createSuccess "test.csv" 10 ]
+
         let successResult = ImportResult.createSuccess 1 10 importedData fileResults 1000L
         Assert.That(successResult.Success, Is.True, "Success result should be successful")
         Assert.That(successResult.ProcessedRecords, Is.EqualTo(10), "Should have processed 10 records")
         Assert.That(successResult.ProcessingTimeMs, Is.EqualTo(1000L), "Should have correct processing time")
-        
-        let cancelledResult = ImportResult.createCancelled()
+
+        let cancelledResult = ImportResult.createCancelled ()
         Assert.That(cancelledResult.Success, Is.False, "Cancelled result should not be successful")
-        Assert.That(cancelledResult.ProcessedRecords, Is.EqualTo(0), "Cancelled result should have no processed records")
-        
-        let errorResult = ImportResult.createError("Test error")
+
+        Assert.That(
+            cancelledResult.ProcessedRecords,
+            Is.EqualTo(0),
+            "Cancelled result should have no processed records"
+        )
+
+        let errorResult = ImportResult.createError ("Test error")
         Assert.That(errorResult.Success, Is.False, "Error result should not be successful")
         Assert.That(errorResult.Errors.Length, Is.EqualTo(1), "Should have one error")
         Assert.That(errorResult.Errors.[0].ErrorMessage, Is.EqualTo("Test error"), "Should have correct error message")
@@ -179,21 +234,31 @@ type ImportManagerTests() =
     [<Test>]
     member this.``ImportManager utility functions work correctly``() =
         // Test initial state
-        Assert.That(ImportManager.isImportInProgress(), Is.False, "No import should be in progress initially")
-        Assert.That(ImportManager.getCurrentStatus(), Is.EqualTo(NotStarted), "Status should be NotStarted")
-        
+        Assert.That(ImportManager.isImportInProgress (), Is.False, "No import should be in progress initially")
+        Assert.That(ImportManager.getCurrentStatus (), Is.EqualTo(NotStarted), "Status should be NotStarted")
+
         // Start an import state (but not a full import)
-        ImportState.startImport() |> ignore
-        Assert.That(ImportManager.isImportInProgress(), Is.True, "Import should be in progress")
-        
+        ImportState.startImport () |> ignore
+        Assert.That(ImportManager.isImportInProgress (), Is.True, "Import should be in progress")
+
         // Cancel and verify
-        ImportManager.cancelCurrentImport()
-        Assert.That(ImportManager.isImportInProgress(), Is.False, "Import should not be in progress after cancellation")
-        
+        ImportManager.cancelCurrentImport ()
+
+        Assert.That(
+            ImportManager.isImportInProgress (),
+            Is.False,
+            "Import should not be in progress after cancellation"
+        )
+
         // Test background cancellation
-        ImportState.startImport() |> ignore
-        ImportManager.cancelForBackground()
-        Assert.That(ImportManager.isImportInProgress(), Is.False, "Import should not be in progress after background cancellation")
+        ImportState.startImport () |> ignore
+        ImportManager.cancelForBackground ()
+
+        Assert.That(
+            ImportManager.isImportInProgress (),
+            Is.False,
+            "Import should not be in progress after background cancellation"
+        )
 
     [<Test>]
     member this.``ReactiveManagers are accessible for refresh after successful import``() =
@@ -201,30 +266,33 @@ type ImportManagerTests() =
         // This validates that our changes to ImportManager.fs compilation order work correctly
         try
             // These should not throw exceptions if the compilation order is correct
-            Binnaculum.Core.UI.ReactiveTickerManager.refresh() |> ignore  // Added for cache dependency fix
-            Binnaculum.Core.UI.ReactiveMovementManager.refresh()
-            Binnaculum.Core.UI.ReactiveSnapshotManager.refresh()
+            Binnaculum.Core.UI.ReactiveTickerManager.refresh () |> ignore // Added for cache dependency fix
+            Binnaculum.Core.UI.ReactiveMovementManager.refresh ()
+            Binnaculum.Core.UI.ReactiveSnapshotManager.refresh ()
             // If we get here without exceptions, the test passes
-            Assert.That(true, Is.True, "All reactive managers are accessible and refreshable from ImportManager context")
-        with
-        | ex ->
+            Assert.That(
+                true,
+                Is.True,
+                "All reactive managers are accessible and refreshable from ImportManager context"
+            )
+        with ex ->
             Assert.Fail($"Reactive managers should be accessible from ImportManager context. Error: {ex.Message}")
 
     [<Test>]
-    member this.``ReactiveManagers async refresh methods are accessible and awaitable``() = task {
-        // Test that the new awaitable refresh methods work correctly
-        // This validates the async timing fix for imported data not appearing in UI
-        try
-            // These methods should be awaitable and complete successfully
-            do! ReactiveMovementManager.refreshAsync()
-            do! ReactiveSnapshotManager.refreshAsync()
-            
-            // Verify both sync and async methods are available for backward compatibility
-            ReactiveMovementManager.refresh()
-            ReactiveSnapshotManager.refresh()
-            
-            Assert.That(true, Is.True, "Both sync and async refresh methods are accessible and functional")
-        with
-        | ex ->
-            Assert.Fail($"Async refresh methods should be accessible and awaitable. Error: {ex.Message}")
-    }
+    member this.``ReactiveManagers async refresh methods are accessible and awaitable``() =
+        task {
+            // Test that the new awaitable refresh methods work correctly
+            // This validates the async timing fix for imported data not appearing in UI
+            try
+                // These methods should be awaitable and complete successfully
+                do! ReactiveMovementManager.refreshAsync ()
+                do! ReactiveSnapshotManager.refreshAsync ()
+
+                // Verify both sync and async methods are available for backward compatibility
+                ReactiveMovementManager.refresh ()
+                ReactiveSnapshotManager.refresh ()
+
+                Assert.That(true, Is.True, "Both sync and async refresh methods are accessible and functional")
+            with ex ->
+                Assert.Fail($"Async refresh methods should be accessible and awaitable. Error: {ex.Message}")
+        }

--- a/src/UI/Pages/BrokerMovementCreatorPage.xaml.cs
+++ b/src/UI/Pages/BrokerMovementCreatorPage.xaml.cs
@@ -12,9 +12,9 @@ public partial class BrokerMovementCreatorPage
 {
     private readonly Models.BrokerAccount _account;
 
-	public BrokerMovementCreatorPage(Models.BrokerAccount account)
-	{
-		InitializeComponent();
+    public BrokerMovementCreatorPage(Models.BrokerAccount account)
+    {
+        InitializeComponent();
         _account = account;
 
         Icon.ImagePath = _account.Broker.Image;
@@ -68,9 +68,9 @@ public partial class BrokerMovementCreatorPage
                     || x == Models.MovementType.ACATSecuritiesTransferSent
                     || x == Models.MovementType.ACATSecuritiesTransferReceived
                     || x == Models.MovementType.Conversion
-                    || hiderFeesAndCommissions)                
+                    || hiderFeesAndCommissions)
                     return true;
-                
+
                 return false;
             })
             .ObserveOn(UiThread)
@@ -84,12 +84,12 @@ public partial class BrokerMovementCreatorPage
 
         selection.Select(x =>
             {
-                if(x == Models.MovementType.DividendReceived
+                if (x == Models.MovementType.DividendReceived
                     || x == Models.MovementType.DividendExDate
                     || x == Models.MovementType.DividendPayDate
                     || x == Models.MovementType.DividendTaxWithheld)
                 {
-                    if(x == Models.MovementType.DividendReceived)
+                    if (x == Models.MovementType.DividendReceived)
                         DividendMovement.DividendEditor = DividenEditor.Received;
                     else if (x == Models.MovementType.DividendExDate)
                         DividendMovement.DividendEditor = DividenEditor.ExDividendDate;
@@ -219,7 +219,8 @@ public partial class BrokerMovementCreatorPage
             .Where(isChecked => isChecked)
             .ObserveOn(UiThread)
             .Do(_ => ManualRadioButton.IsChecked = false)
-            .Subscribe(_ => {
+            .Subscribe(_ =>
+            {
                 FileImportSection.IsVisible = true;
                 // Hide manual movement controls
                 MovementTypeControl.IsVisible = false;
@@ -236,7 +237,8 @@ public partial class BrokerMovementCreatorPage
             .Where(isChecked => isChecked)
             .ObserveOn(UiThread)
             .Do(_ => FromFileRadioButton.IsChecked = false)
-            .Subscribe(_ => {
+            .Subscribe(_ =>
+            {
                 FileImportSection.IsVisible = false;
                 MovementTypeControl.IsVisible = true;
                 // Reset import results
@@ -254,7 +256,7 @@ public partial class BrokerMovementCreatorPage
             .Do(_ => ShowImportProgress())
             .Delay(TimeSpan.FromMilliseconds(300)) // Small delay to ensure progress UI is visible
             .ObserveOn(BackgroundScheduler)
-            .CatchCoreError(file => ImportManager.importFile(_account.Broker.Id, file!.FilePath))
+            .CatchCoreError(file => ImportManager.importFile(_account.Broker.Id, _account.Id, file!.FilePath))
             .ObserveOn(UiThread)
             .Do(HandleImportResult)
             .Subscribe()
@@ -302,7 +304,7 @@ public partial class BrokerMovementCreatorPage
         return new Models.BrokerMovement(
                             0,
                             BrokerMovement.DepositData.TimeStamp,
-                            BrokerMovement.ConversionData.AmountTo, 
+                            BrokerMovement.ConversionData.AmountTo,
                             BrokerMovement.ConversionData.CurrencyTo.ToFastCurrency(),
                             _account,
                             BrokerMovement.ConversionData.Commissions,
@@ -346,10 +348,10 @@ public partial class BrokerMovementCreatorPage
         if (movementType.IsLending)
             return true;
 
-        if(movementType.IsInterestsGained)
+        if (movementType.IsInterestsGained)
             return true;
 
-        if(movementType.IsInterestsPaid)
+        if (movementType.IsInterestsPaid)
             return true;
 
         return false;


### PR DESCRIPTION
## Summary
- validate the selected broker account before processing imports
- pass the explicit broker account id through the UI and Maui tester flows
- add a regression test for invalid broker accounts and update docs

## Testing
- dotnet test src/Tests/Core.Tests/Core.Tests.fsproj

Closes #350.